### PR TITLE
Disable addon style builder for Maven projects (#19581)

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/CheckAddonStylesBuilderJob.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/CheckAddonStylesBuilderJob.java
@@ -8,6 +8,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 
 import com.vaadin.integration.eclipse.builder.AddonStylesBuilder;
+import com.vaadin.integration.eclipse.maven.MavenUtil;
 import com.vaadin.integration.eclipse.util.ErrorUtil;
 import com.vaadin.integration.eclipse.util.PreferenceUtil;
 import com.vaadin.integration.eclipse.util.ProjectUtil;
@@ -28,7 +29,8 @@ public class CheckAddonStylesBuilderJob extends Job {
             // project settings
             PreferenceUtil prefUtil = PreferenceUtil.get(project);
             try {
-                if (prefUtil.isAddonThemeScanningSuspended()) {
+                if (prefUtil.isAddonThemeScanningSuspended()
+                        || MavenUtil.isMavenProject(project)) {
                     AddonStylesBuilder.removeBuilder(project);
                 } else {
                     AddonStylesBuilder.addBuilder(project);

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/properties/ThemingParametersComposite.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/properties/ThemingParametersComposite.java
@@ -8,6 +8,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 
 import com.vaadin.integration.eclipse.builder.AddonStylesImporter;
+import com.vaadin.integration.eclipse.maven.MavenUtil;
 
 public class ThemingParametersComposite extends Composite {
 
@@ -38,14 +39,19 @@ public class ThemingParametersComposite extends Composite {
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
         if (suspendAddonThemeScanning != null) {
-            suspendAddonThemeScanning.setEnabled(enabled);
+            suspendAddonThemeScanning.setEnabled(enabled
+                    && !MavenUtil.isMavenProject(project));
         }
     }
 
     public void setProject(IProject project) {
         this.project = project;
-        boolean suspendend = AddonStylesImporter.isSuspended(project);
-        suspendAddonThemeScanning.setSelection(suspendend);
+        if (MavenUtil.isMavenProject(project)) {
+            suspendAddonThemeScanning.setEnabled(false);
+        } else {
+            boolean suspendend = AddonStylesImporter.isSuspended(project);
+            suspendAddonThemeScanning.setSelection(suspendend);
+        }
     }
 
     public boolean isAddonScanningSuspended() {

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/properties/VaadinProjectPropertyPage.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/properties/VaadinProjectPropertyPage.java
@@ -30,6 +30,7 @@ import org.eclipse.ui.dialogs.PropertyPage;
 import com.vaadin.integration.eclipse.builder.AddonStylesBuilder;
 import com.vaadin.integration.eclipse.builder.AddonStylesImporter;
 import com.vaadin.integration.eclipse.builder.WidgetsetBuildManager;
+import com.vaadin.integration.eclipse.maven.MavenUtil;
 import com.vaadin.integration.eclipse.properties.VaadinVersionComposite.VersionSelectionChangeListener;
 import com.vaadin.integration.eclipse.util.ErrorUtil;
 import com.vaadin.integration.eclipse.util.PreferenceUtil;
@@ -151,7 +152,8 @@ public class VaadinProjectPropertyPage extends PropertyPage {
                     performDefaults();
                 }
             }
-            if (themingComposite.isAddonScanningSuspended()) {
+            if (themingComposite.isAddonScanningSuspended()
+                    || MavenUtil.isMavenProject(project)) {
                 AddonStylesBuilder.removeBuilder(project);
             } else {
                 AddonStylesBuilder.addBuilder(project);


### PR DESCRIPTION
This disables the Eclipse addon style builder for Maven projects,
and disables the corresponding option in project properties.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/4)

<!-- Reviewable:end -->
