### PR TITLE
Support both old and new m2e versions

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/AbstractCreateMavenProjectJob.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/AbstractCreateMavenProjectJob.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2010 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package com.vaadin.integration.eclipse.wizards;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.m2e.core.project.IMavenProjectImportResult;
+import org.eclipse.m2e.core.ui.internal.actions.OpenMavenConsoleAction;
+import org.eclipse.m2e.core.ui.internal.wizards.AbstractCreateMavenProjectsOperation;
+import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.progress.IProgressConstants;
+
+// class copied from old m2e and renamed to support both old and new m2e versions where the class names differ
+public abstract class AbstractCreateMavenProjectJob extends WorkspaceJob {
+
+    private final List<IWorkingSet> workingSets;
+
+    public AbstractCreateMavenProjectJob(String name,
+            List<IWorkingSet> workingSets) {
+        super(name);
+        this.workingSets = workingSets;
+    }
+
+    @Override
+    public final IStatus runInWorkspace(IProgressMonitor monitor)
+            throws CoreException {
+        setProperty(IProgressConstants.ACTION_PROPERTY,
+                new OpenMavenConsoleAction());
+        AbstractCreateMavenProjectsOperation op = new AbstractCreateMavenProjectsOperation(
+                workingSets) {
+            @Override
+            protected List<IProject> doCreateMavenProjects(
+                    IProgressMonitor monitor) throws CoreException {
+                return AbstractCreateMavenProjectJob.this
+                        .doCreateMavenProjects(monitor);
+            }
+        };
+        try {
+            op.run(monitor);
+        } catch (InvocationTargetException e) {
+            return AbstractCreateMavenProjectsOperation.toStatus(e);
+        } catch (InterruptedException e) {
+            return Status.CANCEL_STATUS;
+        }
+        return Status.OK_STATUS;
+    }
+
+    protected abstract List<IProject> doCreateMavenProjects(
+            IProgressMonitor monitor) throws CoreException;
+
+    protected static ArrayList<IProject> toProjects(
+            List<IMavenProjectImportResult> results) {
+        ArrayList<IProject> projects = new ArrayList<IProject>();
+        for (IMavenProjectImportResult result : results) {
+            if (result.getProject() != null) {
+                projects.add(result.getProject());
+            }
+        }
+        return projects;
+    }
+
+}

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -22,7 +22,6 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.ui.internal.MavenImages;
 import org.eclipse.m2e.core.ui.internal.Messages;
-import org.eclipse.m2e.core.ui.internal.wizards.AbstactCreateMavenProjectJob;
 import org.eclipse.m2e.core.ui.internal.wizards.AbstractMavenProjectWizard;
 import org.eclipse.m2e.core.ui.internal.wizards.MavenProjectWizardArchetypeParametersPage;
 import org.eclipse.osgi.util.NLS;
@@ -206,7 +205,7 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
         final String javaPackage = parametersPage.getJavaPackage();
         final Properties properties = parametersPage.getProperties();
 
-        job = new AbstactCreateMavenProjectJob(NLS.bind(
+        job = new AbstractCreateMavenProjectJob(NLS.bind(
                 Messages.wizardProjectJobCreating, archetype.getArtifactId()),
                 workingSets) {
             @Override


### PR DESCRIPTION
New m2e versions (1.6.2+) have renamed a class that had a typo in its
name. This change adds a copy of the class to the project to work with
both old and new versions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/55)

<!-- Reviewable:end -->
