### PR TITLE
Provide default group and artifact id for new maven projects

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -168,7 +168,7 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
                 // overriding this class.
 
                 // If package is not customized before setting visible, we
-                // should restrore it to not being customized.
+                // should restore it to not being customized.
                 boolean shouldRestore = !packageCustomized;
 
                 super.setVisible(visible);
@@ -177,10 +177,8 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
                 String artifact = artifactIdCombo.getText();
 
                 // Only restore if groupId and artifactId match the defaults.
-                if (shouldRestore
-                        && (group != null && group.equals(DEFAULT_GROUP_ID))
-                        && (artifact != null && artifact
-                                .equals(DEFAULT_ARTIFACT_ID))) {
+                if (shouldRestore && (DEFAULT_GROUP_ID.equals(group))
+                        && (DEFAULT_ARTIFACT_ID.equals(artifact))) {
                     packageCustomized = false;
                 }
             }

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -143,20 +143,46 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
         parametersPage = new MavenProjectWizardArchetypeParametersPage(
                 importConfiguration) {
 
+            private static final String DEFAULT_GROUP_ID = "com.example";
+            private static final String DEFAULT_ARTIFACT_ID = "myapplication";
+
             @Override
             public void createControl(Composite parent) {
                 super.createControl(parent);
 
                 // Input some default values.
                 if (groupIdCombo.getText().isEmpty()) {
-                    groupIdCombo.setText("com.example");
+                    groupIdCombo.setText(DEFAULT_GROUP_ID);
                 }
 
                 if (artifactIdCombo.getText().isEmpty()) {
-                    artifactIdCombo.setText("myapplication");
+                    artifactIdCombo.setText(DEFAULT_ARTIFACT_ID);
                 }
+            }
 
-                updateJavaPackage();
+            @Override
+            public void setVisible(boolean visible) {
+                // This is a workaround for setVisible setting package as
+                // customized, even though the user never actually customized
+                // it. The customization from wizards point of view was done by
+                // overriding this class.
+
+                // If package is not customized before setting visible, we
+                // should restrore it to not being customized.
+                boolean shouldRestore = !packageCustomized;
+
+                super.setVisible(visible);
+
+                String group = groupIdCombo.getText();
+                String artifact = artifactIdCombo.getText();
+
+                // Only restore if groupId and artifactId match the defaults.
+                if (shouldRestore
+                        && (group != null && group.equals(DEFAULT_GROUP_ID))
+                        && (artifact != null && artifact
+                                .equals(DEFAULT_ARTIFACT_ID))) {
+                    packageCustomized = false;
+                }
             }
         };
 

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -25,6 +25,7 @@ import org.eclipse.m2e.core.ui.internal.Messages;
 import org.eclipse.m2e.core.ui.internal.wizards.AbstractMavenProjectWizard;
 import org.eclipse.m2e.core.ui.internal.wizards.MavenProjectWizardArchetypeParametersPage;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 
@@ -140,7 +141,24 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
          * Archetype parameters page. The only needed page for Vaadin Archetype.
          */
         parametersPage = new MavenProjectWizardArchetypeParametersPage(
-                importConfiguration);
+                importConfiguration) {
+
+            @Override
+            public void createControl(Composite parent) {
+                super.createControl(parent);
+
+                // Input some default values.
+                if (groupIdCombo.getText().isEmpty()) {
+                    groupIdCombo.setText("com.example");
+                }
+
+                if (artifactIdCombo.getText().isEmpty()) {
+                    artifactIdCombo.setText("myapplication");
+                }
+
+                updateJavaPackage();
+            }
+        };
 
         addPage(vaadinArchetypeSelectionPage);
         addPage(parametersPage);


### PR DESCRIPTION
This patch sets default values to parameter page when creating controls

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/160)

<!-- Reviewable:end -->
