### PR TITLE
Add update goals to widgetset and theme compilation

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/MavenUtil.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/MavenUtil.java
@@ -43,17 +43,20 @@ public class MavenUtil {
     }
 
     public static boolean compileWidgetSet(ISelection currentSelection) {
-        runMavenGoal(currentSelection, "vaadin:compile");
+        runMavenGoal(currentSelection, "vaadin:update-widgetset vaadin:compile");
         return true;
     }
 
     public static boolean compileTheme(ISelection currentSelection) {
-        runMavenGoal(currentSelection, "vaadin:compile-theme");
+        runMavenGoal(currentSelection,
+                "vaadin:update-theme vaadin:compile-theme");
         return true;
     }
 
     public static boolean compileThemeAndWidgetset(ISelection currentSelection) {
-        runMavenGoal(currentSelection, "vaadin:compile-theme vaadin:compile");
+        runMavenGoal(
+                currentSelection,
+                "vaadin:update-theme vaadin:update-widgetset vaadin:compile-theme vaadin:compile");
         return true;
     }
 }


### PR DESCRIPTION
This provides easier adding of add-ons to a project. Running the compilation after pom file modification is making all needed updates as well. The impact on the actual build time is minimal.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/331)

<!-- Reviewable:end -->
