### PR TITLE
Compile theme/widgetset with Maven based on selection/editor

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/handlers/AbstractCompileJob.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/handlers/AbstractCompileJob.java
@@ -11,6 +11,8 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.ui.IEditorPart;
 
 import com.vaadin.integration.eclipse.maven.MavenUtil;
@@ -41,7 +43,13 @@ public abstract class AbstractCompileJob extends Job {
                     activeEditor);
             boolean compiled = false;
             if (MavenUtil.isMavenProject(selectedProject)) {
-                compiled = handleMavenProject(currentSelection);
+                // Convert selection if necessary as runMavenGoal only
+                // understands certain kinds of selection.
+                // We only need to know the project, as it is only used to find
+                // the base directory.
+                IStructuredSelection selection = new StructuredSelection(
+                        selectedProject);
+                compiled = handleMavenProject(selection);
             } else {
                 compiled = handleIvyProject(currentSelection, activeEditor,
                         monitor);


### PR DESCRIPTION
Use a "fake selection" to expand the supported selections for compiling
the theme and the widgetset with Maven.

This supports detecting the project to compile based on the file open
in the editor and many (but not all) pseudo-elements in the
Project Explorer view.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/653)

<!-- Reviewable:end -->
