### PR TITLE
Add travis and default profiles to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,6 @@
   <groupId>com.vaadin.eclipse</groupId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <modules>
-    <module>com.vaadin.integration.eclipse</module>
-    <module>feature</module>
-    <module>legacy-feature</module>
-    <module>update-site</module>
-  </modules>
 
   <properties>
     <updatesite.url>No update site defined</updatesite.url>
@@ -132,4 +126,31 @@
     </plugins>
   </build>
   <artifactId>integration-root</artifactId>
+
+  <profiles>
+    <profile>
+      <id>travis</id>
+      <activation>
+        <property>
+          <name>env.TRAVIS</name>
+        </property>
+      </activation>
+      <modules>
+        <module>com.vaadin.integration.eclipse</module>
+         <module>feature</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>com.vaadin.integration.eclipse</module>
+        <module>feature</module>
+        <module>legacy-feature</module>
+        <module>update-site</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
       </activation>
       <modules>
         <module>com.vaadin.integration.eclipse</module>
-         <module>feature</module>
+        <module>feature</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
This fixes the issue with the newly changed behaviour of the legacy-feature and update-site. Missing dependency should no longer break the whole build.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/658)

<!-- Reviewable:end -->
