### PR TITLE
Fix theme and widgetset wizards with Maven

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/ProjectUtil.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/ProjectUtil.java
@@ -609,6 +609,16 @@ public class ProjectUtil {
     }
     -*/
 
+    /**
+     * Check that the project has Vaadin 7 or later on its classpath.
+     * 
+     * Effectively this method checks for the existence of the class
+     * com.vaadin.ui.UI on the classpath.
+     * 
+     * @param project
+     *            project to check
+     * @return true if the project uses Vaadin 7 or later
+     */
     public static boolean isVaadin7(IProject project) {
         try {
             // String vaadinVersion = getVaadinLibraryVersion(project, true);
@@ -616,7 +626,7 @@ public class ProjectUtil {
             IType uiType = findVaadinUiType(JavaCore.create(project));
             return (null != uiType);
         } catch (CoreException e) {
-            ErrorUtil.handleBackgroundException("", e);
+            // ErrorUtil.handleBackgroundException("", e);
             return false;
         }
     }

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/AbstractVaadinNewTypeWizardPage.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/AbstractVaadinNewTypeWizardPage.java
@@ -10,9 +10,9 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ui.wizards.NewContainerWizardPage;
 import org.eclipse.jdt.ui.wizards.NewTypeWizardPage;
 
-import com.vaadin.integration.eclipse.VaadinFacetUtils;
 import com.vaadin.integration.eclipse.VaadinPlugin;
 import com.vaadin.integration.eclipse.util.ErrorUtil;
+import com.vaadin.integration.eclipse.util.ProjectUtil;
 
 public abstract class AbstractVaadinNewTypeWizardPage extends NewTypeWizardPage {
 
@@ -34,7 +34,7 @@ public abstract class AbstractVaadinNewTypeWizardPage extends NewTypeWizardPage 
         IJavaProject jp = JavaCore.create(project);
         // do as other wizards do: allow showing page even if no project
         // exists
-        if (jp != null && VaadinFacetUtils.isVaadinProject(project)) {
+        if (jp != null && ProjectUtil.isVaadin7(project)) {
             // this will also call setProjectInternal(IProject)
             try {
                 IPackageFragmentRoot[] roots = jp.getPackageFragmentRoots();
@@ -61,7 +61,7 @@ public abstract class AbstractVaadinNewTypeWizardPage extends NewTypeWizardPage 
     protected void setProjectInternal(IProject project) {
         this.project = project;
 
-        if (project == null || !VaadinFacetUtils.isVaadinProject(project)) {
+        if (project == null || !ProjectUtil.isVaadin7(project)) {
             setPackageFragment(null, false);
             setTypeName("", false);
             return;
@@ -116,7 +116,7 @@ public abstract class AbstractVaadinNewTypeWizardPage extends NewTypeWizardPage 
 
     protected IStatus[] getStatus() {
         IStatus[] status;
-        if (project == null || !VaadinFacetUtils.isVaadinProject(project)) {
+        if (project == null || !ProjectUtil.isVaadin7(project)) {
             status = new Status[] { new Status(IStatus.ERROR,
                     VaadinPlugin.PLUGIN_ID, "No suitable project found.") };
         } else {

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/NewComponentWizardPage.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/NewComponentWizardPage.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
-import com.vaadin.integration.eclipse.VaadinFacetUtils;
 import com.vaadin.integration.eclipse.VaadinPlugin;
 import com.vaadin.integration.eclipse.templates.TEMPLATES;
 import com.vaadin.integration.eclipse.util.ErrorUtil;
@@ -93,7 +92,7 @@ public class NewComponentWizardPage extends AbstractVaadinNewTypeWizardPage {
         }
 
         // show the page even when there is no project - eclipse guidelines
-        if (project == null || !VaadinFacetUtils.isVaadinProject(project)) {
+        if (project == null || !ProjectUtil.isVaadin7(project)) {
             return;
         }
 

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/NewThemeWizardPage.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/NewThemeWizardPage.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 
-import com.vaadin.integration.eclipse.VaadinFacetUtils;
 import com.vaadin.integration.eclipse.VaadinPlugin;
 import com.vaadin.integration.eclipse.util.ProjectUtil;
 import com.vaadin.integration.eclipse.viewers.ApplicationList;
@@ -68,7 +67,7 @@ public class NewThemeWizardPage extends WizardPage {
         projectCombo.setLayoutData(gd);
         for (IProject project : ResourcesPlugin.getWorkspace().getRoot()
                 .getProjects()) {
-            if (VaadinFacetUtils.isVaadinProject(project)) {
+            if (ProjectUtil.isVaadin7(project)) {
                 projectCombo.add(project.getName());
             }
         }


### PR DESCRIPTION
This change makes the wizards accept Maven projects as Vaadin projects.

Also, removed some unnecessarily noisy error logging in project type detection.

Note that the widget wizard still has some issues with multi-module
projects.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/659)

<!-- Reviewable:end -->
