### PR TITLE
Support pre-release archetypes

### DIFF
--- a/com.vaadin.integration.eclipse/plugin.xml
+++ b/com.vaadin.integration.eclipse/plugin.xml
@@ -536,5 +536,13 @@ Any metadata changes made will be stored in the project manifest.
    <extension
          point="org.eclipse.m2e.core.lifecycleMappingMetadataSource">
    </extension>
+   <!-- To enable the prerelease archetype catalog for general use, uncomment this once the file replication is done -->
+   <!-- Note that this is not required for using the pre-release archetypes on the list retrieved from vaadin.com . -->
+<!--
+   <extension point="org.eclipse.m2e.core.archetypeCatalogs">
+      <remote url="http://maven.vaadin.com/vaadin-prereleases/" description="Vaadin pre-release archetypes">
+      </remote>
+   </extension>
+-->
    
 </plugin>

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/PreferenceConstants.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/PreferenceConstants.java
@@ -54,4 +54,11 @@ public class PreferenceConstants {
 
     public static final String NOTIFICATIONS_SETTINGS_URL = "notificationsSettingsUrlPreference";
 
+    /*
+     * =========================================================================
+     * Pre-release settings
+     */
+
+    public static final String PRERELEASE_ARCHETYPES_ENABLED = "prereleaseArchetypesEnabledPreference";
+
 }

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/PreferenceInitializer.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/PreferenceInitializer.java
@@ -31,6 +31,9 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
                 PreferenceConstants.NOTIFICATIONS_NEW_VERSION_POPUP_ENABLED,
                 true);
 
+        store.setDefault(PreferenceConstants.PRERELEASE_ARCHETYPES_ENABLED,
+                false);
+
         /*
          * Migrate old settings here if they exists.
          */

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/VaadinPreferences.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/preferences/VaadinPreferences.java
@@ -64,6 +64,8 @@ public class VaadinPreferences extends PreferencePage
 
         createNotificationsSection(composite);
 
+        createPrereleaseSection(composite);
+
         // checkState();
         return composite;
     }
@@ -115,6 +117,30 @@ public class VaadinPreferences extends PreferencePage
         createUpdateSection(panel);
 
         updateNotificationContols(enabled);
+    }
+
+    private void createPrereleaseSection(Composite composite) {
+        final ExpandableComposite expandable = new ExpandableComposite(
+                composite, SWT.FILL, ExpandableComposite.TWISTIE
+                        | ExpandableComposite.CLIENT_INDENT);
+        expandable.setExpanded(false);
+        GridData data = new GridData();
+        data.horizontalAlignment = SWT.FILL;
+        data.grabExcessHorizontalSpace = true;
+        expandable.setLayoutData(data);
+
+        expandable.addExpansionListener(new ExpansionListener());
+
+        Composite panel = new Composite(expandable, SWT.NONE);
+        expandable.setClient(panel);
+        panel.setLayout(new GridLayout(1, false));
+        expandable.setText("Vaadin Pre-releases");
+        expandable.setFont(CommonFonts.BOLD);
+
+        final VaadinBooleanFieldEditor enabled = new VaadinBooleanFieldEditor(
+                PreferenceConstants.PRERELEASE_ARCHETYPES_ENABLED,
+                "Enable Vaadin pre-release archetypes", panel, true);
+        addField(enabled);
     }
 
     private void createUpdateSection(Composite panel) {

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/MavenVersionManager.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/MavenVersionManager.java
@@ -27,15 +27,22 @@ import com.vaadin.integration.eclipse.wizards.VaadinArchetype;
 
 public class MavenVersionManager {
 
+    private static final String PRERELEASE_REPOSITORY_URL = "http://maven.vaadin.com/vaadin-prereleases/";
+
     private static final String VERSIONS_FILE_NAME = "VERSIONS_7";
 
     private static final String ARCHETYPES_FILE_NAME = "maven-archetypes.xml";
+    private static final String PRERELEASE_ARCHETYPES_FILE_NAME = "maven-archetypes-prerelease.xml";
 
     private static final String AVAILABLE_VAADIN_VERSIONS_7_URL = DownloadManager.VAADIN_DOWNLOAD_BASE_URL
             + VERSIONS_FILE_NAME;
 
     private static final String AVAILABLE_VAADIN_ARCHETYPES_URL = DownloadManager.VAADIN_DOWNLOAD_BASE_URL
             + ARCHETYPES_FILE_NAME;
+
+    private static final String AVAILABLE_VAADIN_PRERELEASE_ARCHETYPES_URL = DownloadManager.VAADIN_DOWNLOAD_BASE_URL
+            + PRERELEASE_ARCHETYPES_FILE_NAME;
+
 
     private static List<MavenVaadinVersion> availableVersions;
     
@@ -45,10 +52,13 @@ public class MavenVersionManager {
      * Returns a list of available Vaadin archetypes. It is not guaranteed that
      * the list is fetched from the site every time this is called.
      * 
+     * @param includePrereleases
+     *            true to also return pre-release versions of archetypes
      * @return A sorted list of available Vaadin archetypes
      * @throws CoreException
      */
-    public static synchronized List<VaadinArchetype> getAvailableArchetypes() {
+    public static synchronized List<VaadinArchetype> getAvailableArchetypes(
+            boolean includePrereleases) {
         if (availableArchetypes == null) {
             try {
                 loadAndCacheResource(AVAILABLE_VAADIN_ARCHETYPES_URL,
@@ -60,11 +70,32 @@ public class MavenVersionManager {
                                 e);
             }
             try {
-                availableArchetypes = loadCachedArchetypes();
+                availableArchetypes = loadCachedArchetypes(ARCHETYPES_FILE_NAME);
             } catch (CoreException e) {
                 ErrorUtil.handleBackgroundException(
                         "Failed to load cached Vaadin archetypes", e);
             }
+
+            if (includePrereleases) {
+                // if this fails, just ignore it
+                try {
+                    loadAndCacheResource(
+                            AVAILABLE_VAADIN_PRERELEASE_ARCHETYPES_URL,
+                            PRERELEASE_ARCHETYPES_FILE_NAME);
+                    List<VaadinArchetype> prereleaseArchetypes = loadCachedArchetypes(PRERELEASE_ARCHETYPES_FILE_NAME);
+                    for (VaadinArchetype prereleaseArchetype : prereleaseArchetypes) {
+                        prereleaseArchetype.getArchetype().setRepository(
+                                PRERELEASE_REPOSITORY_URL);
+                    }
+                    availableArchetypes.addAll(prereleaseArchetypes);
+                } catch (Exception e) {
+                    ErrorUtil
+                            .handleBackgroundException(
+                                    "Failed to load the list of pre-release archetypes",
+                                    e);
+                }
+            }
+
             if (availableArchetypes == null){
                 availableArchetypes = loadDefaultArchetypes();
             }
@@ -72,10 +103,9 @@ public class MavenVersionManager {
         return availableArchetypes;
     }
 
-
-    private static List<VaadinArchetype> loadCachedArchetypes()
+    private static List<VaadinArchetype> loadCachedArchetypes(String filename)
             throws CoreException {
-        File file = getCacheFile(ARCHETYPES_FILE_NAME);
+        File file = getCacheFile(filename);
         InputStream is = null;
         try {
             is = new BufferedInputStream(new FileInputStream(file));

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/MavenVersionManager.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/MavenVersionManager.java
@@ -45,8 +45,9 @@ public class MavenVersionManager {
 
 
     private static List<MavenVaadinVersion> availableVersions;
-    
-    private static List<VaadinArchetype> availableArchetypes;
+
+    private static List<VaadinArchetype> releaseArchetypes;
+    private static List<VaadinArchetype> prereleaseArchetypes;
 
     /**
      * Returns a list of available Vaadin archetypes. It is not guaranteed that
@@ -59,7 +60,7 @@ public class MavenVersionManager {
      */
     public static synchronized List<VaadinArchetype> getAvailableArchetypes(
             boolean includePrereleases) {
-        if (availableArchetypes == null) {
+        if (releaseArchetypes == null) {
             try {
                 loadAndCacheResource(AVAILABLE_VAADIN_ARCHETYPES_URL,
                         ARCHETYPES_FILE_NAME);
@@ -70,24 +71,25 @@ public class MavenVersionManager {
                                 e);
             }
             try {
-                availableArchetypes = loadCachedArchetypes(ARCHETYPES_FILE_NAME);
+                releaseArchetypes = loadCachedArchetypes(ARCHETYPES_FILE_NAME);
             } catch (CoreException e) {
                 ErrorUtil.handleBackgroundException(
                         "Failed to load cached Vaadin archetypes", e);
             }
 
             if (includePrereleases) {
-                // if this fails, just ignore it
+                // if anything here fails, just ignore all pre-releases
                 try {
                     loadAndCacheResource(
                             AVAILABLE_VAADIN_PRERELEASE_ARCHETYPES_URL,
                             PRERELEASE_ARCHETYPES_FILE_NAME);
-                    List<VaadinArchetype> prereleaseArchetypes = loadCachedArchetypes(PRERELEASE_ARCHETYPES_FILE_NAME);
-                    for (VaadinArchetype prereleaseArchetype : prereleaseArchetypes) {
-                        prereleaseArchetype.getArchetype().setRepository(
-                                PRERELEASE_REPOSITORY_URL);
+                    prereleaseArchetypes = loadCachedArchetypes(PRERELEASE_ARCHETYPES_FILE_NAME);
+                    if (prereleaseArchetypes != null) {
+                        for (VaadinArchetype prereleaseArchetype : prereleaseArchetypes) {
+                            prereleaseArchetype.getArchetype().setRepository(
+                                    PRERELEASE_REPOSITORY_URL);
+                        }
                     }
-                    availableArchetypes.addAll(prereleaseArchetypes);
                 } catch (Exception e) {
                     ErrorUtil
                             .handleBackgroundException(
@@ -96,10 +98,17 @@ public class MavenVersionManager {
                 }
             }
 
-            if (availableArchetypes == null){
-                availableArchetypes = loadDefaultArchetypes();
+            if (releaseArchetypes == null) {
+                releaseArchetypes = loadDefaultArchetypes();
             }
         }
+
+        List<VaadinArchetype> availableArchetypes = new ArrayList<VaadinArchetype>(
+                releaseArchetypes);
+        if (includePrereleases && prereleaseArchetypes != null) {
+            availableArchetypes.addAll(prereleaseArchetypes);
+        }
+
         return availableArchetypes;
     }
 

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.PlatformUI;
 
 import com.vaadin.integration.eclipse.VaadinPlugin;
+import com.vaadin.integration.eclipse.preferences.PreferenceConstants;
 import com.vaadin.integration.eclipse.util.network.MavenVersionManager;
 
 @SuppressWarnings("restriction")
@@ -77,8 +78,10 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
         setHelpAvailable(true);
         setNeedsProgressMonitor(true);
 
-        // TODO use a parameter for the pre-release flag
-        vaadinArchetypes = MavenVersionManager.getAvailableArchetypes(false);
+        boolean prereleases = VaadinPlugin.getInstance().getPreferenceStore()
+                .getBoolean(PreferenceConstants.PRERELEASE_ARCHETYPES_ENABLED);
+        vaadinArchetypes = MavenVersionManager
+                .getAvailableArchetypes(prereleases);
     }
 
     @Override

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectWizard.java
@@ -77,7 +77,8 @@ public class Vaadin7MavenProjectWizard extends AbstractMavenProjectWizard
         setHelpAvailable(true);
         setNeedsProgressMonitor(true);
 
-        vaadinArchetypes = MavenVersionManager.getAvailableArchetypes();
+        // TODO use a parameter for the pre-release flag
+        vaadinArchetypes = MavenVersionManager.getAvailableArchetypes(false);
     }
 
     @Override


### PR DESCRIPTION
Provide an option to include pre-release archetypes on the list of available project types.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/673)

<!-- Reviewable:end -->
