### PR TITLE
Configure source paths for CDN

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/VaadinMavenProjectConfigurator.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/VaadinMavenProjectConfigurator.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
@@ -19,6 +20,13 @@ import org.eclipse.m2e.jdt.AbstractSourcesGenerationProjectConfigurator;
 public class VaadinMavenProjectConfigurator extends
         AbstractSourcesGenerationProjectConfigurator {
 
+    private static final String WIDGETSET_MODE_PARAMETER = "widgetsetMode";
+    private static final String WIDGETSET_GENERATED_SOURCE_DIRECTORY_PARAMETER = "generatedSourceDirectory";
+    private static final String WIDGETSET_GENERATED_RESOURCE_DIRECTORY = "generatedWidgetsetDirectory";
+
+    private static final String WIDGETSET_MODE_VALUE_CDN = "cdn";
+    private static final String WIDGETSET_MODE_VALUE_FETCH = "fetch";
+
     @Override
     public AbstractBuildParticipant getBuildParticipant( IMavenProjectFacade projectFacade,
                                                          MojoExecution execution,
@@ -31,12 +39,71 @@ public class VaadinMavenProjectConfigurator extends
     protected File[] getSourceFolders(ProjectConfigurationRequest request,
             MojoExecution mojoExecution, IProgressMonitor monitor)
             throws CoreException {
-        // if there is no execution defined for update-widgetset, skip updating
-        // the classpath
-        if (!"update-widgetset".equals(mojoExecution.getGoal())) {
-            return new File[0];
+        try {
+            monitor.beginTask(
+                    "Configuring generated source and resource folders", 2);
+
+            String mode = getParameterValue(request.getMavenProject(),
+                    WIDGETSET_MODE_PARAMETER, String.class, mojoExecution,
+                    new SubProgressMonitor(monitor, 1));
+            boolean isCdn = WIDGETSET_MODE_VALUE_CDN.equals(mode)
+                    || WIDGETSET_MODE_VALUE_FETCH.equals(mode);
+
+            if (VaadinMojoExecutionBuildParticipant.COMPILE_WIDGETSET_GOAL
+                    .equals(mojoExecution.getGoal())) {
+                return getCompileMojoSourceFolders(request, mojoExecution,
+                        monitor, isCdn);
+            } else if (VaadinMojoExecutionBuildParticipant.UPDATE_WIDGETSET_GOAL
+                    .equals(mojoExecution
+                    .getGoal())) {
+                return getUpdateWidgetsetMojoSourceDirectories(request,
+                        mojoExecution, monitor, isCdn);
+            } else {
+                // all other cases: skip updating the classpath
+                return new File[0];
+            }
+        } finally {
+            monitor.done();
         }
-        return super.getSourceFolders(request, mojoExecution, monitor);
+    }
+
+    private File[] getCompileMojoSourceFolders(
+            ProjectConfigurationRequest request, MojoExecution mojoExecution,
+            IProgressMonitor monitor, boolean isCdn) throws CoreException {
+        // add wscdn directory if using CDN mode
+        if (isCdn) {
+            // add the location of the generated sources for the
+            // widgetset WebListener
+            File widgetsetSourceDirectory = getParameterValue(
+                    request.getMavenProject(),
+                    WIDGETSET_GENERATED_SOURCE_DIRECTORY_PARAMETER, File.class,
+                    mojoExecution, new SubProgressMonitor(monitor, 1));
+            if (widgetsetSourceDirectory != null) {
+                return new File[] { widgetsetSourceDirectory };
+            } else {
+                // fallback for earlier appwidgetset builds of the Maven
+                // plug-in
+                // TODO this can be removed after the public release of
+                // the appwidgetset features
+                widgetsetSourceDirectory = new File(request.getMavenProject()
+                        .getBasedir(), "target/generated-sources/wscdn");
+                if (widgetsetSourceDirectory != null) {
+                    return new File[] { widgetsetSourceDirectory };
+                }
+            }
+        }
+        return new File[0];
+    }
+
+    private File[] getUpdateWidgetsetMojoSourceDirectories(
+            ProjectConfigurationRequest request, MojoExecution mojoExecution,
+            IProgressMonitor monitor, boolean isCdn) throws CoreException {
+        // do not add the AppWidgetset.gwt.xml directory if using CDN
+        if (!isCdn) {
+            return super.getSourceFolders(request, mojoExecution,
+                    new SubProgressMonitor(monitor, 1));
+        }
+        return new File[0];
     }
 
     @Override
@@ -50,7 +117,7 @@ public class VaadinMavenProjectConfigurator extends
 
     @Override
     protected String getOutputFolderParameterName() {
-        return "generatedWidgetsetDirectory";
+        return WIDGETSET_GENERATED_RESOURCE_DIRECTORY;
     }
 
 }

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/VaadinMojoExecutionBuildParticipant.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/maven/VaadinMojoExecutionBuildParticipant.java
@@ -38,11 +38,13 @@ import com.vaadin.integration.eclipse.preferences.PreferenceConstants;
  */
 public class VaadinMojoExecutionBuildParticipant extends
         MojoExecutionBuildParticipant {
-    private static final String COMPILE_WIDGETSET_GOAL = "compile";
+
+    public static final String COMPILE_WIDGETSET_GOAL = "compile";
+    public static final String UPDATE_THEME_GOAL = "update-theme";
+    public static final String COMPILE_THEME_GOAL = "compile-theme";
+    public static final String UPDATE_WIDGETSET_GOAL = "update-widgetset";
+
     private static final String WS_UPDATED_FILE = "ws-updated";
-    private static final String UPDATE_THEME_GOAL = "update-theme";
-    private static final String COMPILE_THEME_GOAL = "compile-theme";
-    private static final String UPDATE_WIDGETSET_GOAL = "update-widgetset";
 
     private static final String RELATIVE_THEME_DIRECTORY = "VAADIN/themes";
     private static final String GENERATED_WIDGETSET_DIRECTORY_PARAMETER = "generatedWidgetsetDirectory";


### PR DESCRIPTION
Note that the user must perform "Maven -> Update Project..." after changing the widgetset mode to correctly update the generated source paths.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/683)

<!-- Reviewable:end -->
