### PR TITLE
Fix selection of archetype radio buttons

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectArchetypeSelectionView.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/wizards/Vaadin7MavenProjectArchetypeSelectionView.java
@@ -62,13 +62,18 @@ public class Vaadin7MavenProjectArchetypeSelectionView extends
             btnArchetype.setLayoutData(btnGridData);
             vaadinArchetypeButtons.add(btnArchetype);
 
+            final VaadinArchetype archetype = vaadinArch;
+
             MouseListener btnActivateListener = new MouseAdapter() {
 
                 @Override
                 public void mouseDown(MouseEvent arg0) {
-                    btnArchetype.setFocus();
-                    btnArchetype.setSelection(true);
-
+                    // must set the selection for all radio buttons, not just
+                    // this one
+                    selectVaadinArchetype(archetype);
+                    if (isVisible()) {
+                        btnArchetype.setFocus();
+                    }
                 }
             };
 


### PR DESCRIPTION
With the old solution, it was possible to select multiple radio
buttons in the new Vaadin Maven project wizard by clicking on the
text labels, as SWT radio button handling was not invoked.

There doesn't seem to be a clean way to invoke it from the outside,
so iterating over all radio buttons.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/686)

<!-- Reviewable:end -->
