### PR TITLE
Automatically use proxy settings from Eclipse when compiling widget set

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/WidgetsetUtil.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/WidgetsetUtil.java
@@ -177,6 +177,19 @@ public class WidgetsetUtil {
                 }
             }
 
+            String httpProxyHost = System.getProperty("http.proxyHost");
+            String httpProxyPort = System.getProperty("http.proxyPort");
+            String httpsProxyHost = System.getProperty("https.proxyHost");
+            String httpsProxyPort = System.getProperty("https.proxyPort");
+            if (httpProxyHost != null)
+                args.add("-Dhttp.proxyHost="+httpProxyHost);
+            if (httpProxyPort != null)
+                args.add("-Dhttp.proxyPort="+httpProxyPort);
+            if (httpsProxyHost != null)
+                args.add("-Dhttps.proxyHost="+httpsProxyHost);
+            if (httpsProxyPort != null)
+                args.add("-Dhttps.proxyPort="+httpsProxyPort);
+
             // TODO run com.vaadin.terminal.gwt.widgetsetutils.WidgetSetBuilder
             // and com.google.gwt.dev.Compiler separately and directly if Java
             // 6, do not use WidgetsetCompiler in that case

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/WidgetsetUtil.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/WidgetsetUtil.java
@@ -74,7 +74,9 @@ import com.vaadin.integration.eclipse.wizards.DirectoryManifestProvider;
 
 public class WidgetsetUtil {
 
-    private static final String DEFAULT_WIDGET_SET_NAME_VAADIN6 = "com.vaadin.terminal.gwt.DefaultWidgetSet";
+    private static final String[] PROXY_PROPERTIES = {"http.proxyHost","http.proxyPort", "http.nonProxyHosts",
+    		"https.proxyHost","https.proxyPort", "socksProxyHost","socksProxyPort" };
+	private static final String DEFAULT_WIDGET_SET_NAME_VAADIN6 = "com.vaadin.terminal.gwt.DefaultWidgetSet";
     public static final String DEFAULT_WIDGET_SET_NAME = "com.vaadin.DefaultWidgetSet";
 
     /**
@@ -176,25 +178,19 @@ public class WidgetsetUtil {
                     }
                 }
             }
-
-            String httpProxyHost = System.getProperty("http.proxyHost");
-            String httpProxyPort = System.getProperty("http.proxyPort");
-            String httpsProxyHost = System.getProperty("https.proxyHost");
-            String httpsProxyPort = System.getProperty("https.proxyPort");
-            if (httpProxyHost != null)
-                args.add("-Dhttp.proxyHost="+httpProxyHost);
-            if (httpProxyPort != null)
-                args.add("-Dhttp.proxyPort="+httpProxyPort);
-            if (httpsProxyHost != null)
-                args.add("-Dhttps.proxyHost="+httpsProxyHost);
-            if (httpsProxyPort != null)
-                args.add("-Dhttps.proxyPort="+httpsProxyPort);
-
+            
+			for (String propertyName: PROXY_PROPERTIES)
+            {
+	            String propertyValue = System.getProperty(propertyName);
+	            if(propertyValue != null) {
+	            	 args.add("-D" + propertyName + "=" + propertyValue);
+	            }
+            }
             // TODO run com.vaadin.terminal.gwt.widgetsetutils.WidgetSetBuilder
             // and com.google.gwt.dev.Compiler separately and directly if Java
             // 6, do not use WidgetsetCompiler in that case
 
-            ArrayList<String> compilerArgs = new ArrayList<String>(args);
+            List<String> compilerArgs = new ArrayList<String>(args);
             String compilerClass = "com.vaadin.tools.WidgetsetCompiler";
             compilerArgs.add(compilerClass);
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/695)

<!-- Reviewable:end -->
