### PR TITLE
Fix version detection for Vaadin 8.1

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/VersionUtil.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/VersionUtil.java
@@ -127,7 +127,7 @@ public class VersionUtil {
         Attributes attr = manifest.getMainAttributes();
         String bundleName = attr.getValue("Bundle-Name");
         if (bundleName != null
-                && (bundleName.equals("Vaadin") || bundleName
+                && (bundleName.startsWith("Vaadin") || bundleName
                         .startsWith("vaadin-"))) {
             return attr.getValue(versionAttribute);
         }


### PR DESCRIPTION
Detect version correctly also for the manifest bundle names updated in 8.1.

Fixes #745

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/746)
<!-- Reviewable:end -->
