### PR TITLE
Add single notification to list only if it's not null

### DIFF
--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/notifications/model/NotificationsService.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/notifications/model/NotificationsService.java
@@ -493,7 +493,9 @@ public final class NotificationsService {
                     list.add(buildNotification((JSONObject) array.get(i)));
                 }
             } else {
-                list.add(buildNotification((JSONObject) notifications));
+                if (notifications != null) {
+                    list.add(buildNotification((JSONObject) notifications));
+                }
             }
 
             return list;


### PR DESCRIPTION
Prevent NPE exception in buildNotification method by preventing adding singe Notification, if it's null.

Custom NPE stacktrace, which this fix should address :
```
org.eclipse.core.jobs
Error
Sat Sep 15 13:54:54 MST 2018
An internal error occurred during: "Fetch all notifications".

java.lang.NullPointerException
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.getString(NotificationsService.java:747)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.buildNotification(NotificationsService.java:732)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.getNotifications(NotificationsService.java:496)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.access$2(NotificationsService.java:474)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService$3.accept(NotificationsService.java:389)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService$3.accept(NotificationsService.java:1)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.doGet(NotificationsService.java:418)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.getNotifications(NotificationsService.java:397)
	at com.vaadin.integration.eclipse.notifications.model.NotificationsService.getAllNotifications(NotificationsService.java:142)
	at com.vaadin.integration.eclipse.notifications.jobs.FetchNotificationsJob.run(FetchNotificationsJob.java:64)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:60)

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/753)
<!-- Reviewable:end -->
