### PR TITLE
1598: Change http vaadin.com to https

### DIFF
--- a/build/jarbundle-site.xml.tpl
+++ b/build/jarbundle-site.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <description url="http://vaadin.com/eclipse/">
+   <description url="https://vaadin.com/eclipse/">
       Update site for Vaadin.
    </description>
    <feature url="features/com.vaadin.integration.eclipse.jarbundle_@com.vaadin.integration.eclipse.jarbundle-version@.jar" id="com.vaadin.integration.eclipse.jarbundle" version="@com.vaadin.integration.eclipse.jarbundle-version@">

--- a/build/site.xml.tpl
+++ b/build/site.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site associateSitesURL="associateSites.xml">
-   <description url="http://vaadin.com/eclipse/">
+   <description url="https://vaadin.com/eclipse/">
       Update site for Vaadin.
    </description>
    <feature url="features/com.vaadin.integration.eclipse_@com.vaadin.integration.eclipse-version@.jar" id="com.vaadin.integration.eclipse" version="@com.vaadin.integration.eclipse-version@">

--- a/build/src/com/vaadin/integration/eclipse/tools/EclipsePluginDownloader.java
+++ b/build/src/com/vaadin/integration/eclipse/tools/EclipsePluginDownloader.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 
 public class EclipsePluginDownloader {
-    private static final String STABLE_ECLIPSE_SITE_URL = "http://vaadin.com/eclipse";
+    private static final String STABLE_ECLIPSE_SITE_URL = "https://vaadin.com/eclipse";
 
     public static void main(String[] args) throws IOException {
         downloadEclipsePlugin(args[0]);

--- a/build/src/com/vaadin/integration/eclipse/tools/VaadinDownloader.java
+++ b/build/src/com/vaadin/integration/eclipse/tools/VaadinDownloader.java
@@ -14,7 +14,7 @@ import org.apache.commons.io.IOUtils;
 
 public class VaadinDownloader {
 
-    private static final String VAADIN_BASE_URL = "http://vaadin.com/download";
+    private static final String VAADIN_BASE_URL = "https://vaadin.com/download";
     private static final String LATEST_URL = VAADIN_BASE_URL + "/LATEST";
     private static final String VAADIN_VERSION_ATTRIBUTE = "Bundle-version";
     private static final String GWT_VERSION_ATTRIBUTE = "GWT-Version";

--- a/com.vaadin.integration.eclipse/about.html
+++ b/com.vaadin.integration.eclipse/about.html
@@ -7,7 +7,7 @@ Copyright &copy; 2010-2016 Vaadin Ltd. All rights reserved.<br/>
 </b>
 </p>
 <p>
-<a href="http://vaadin.com/">Vaadin Home Page</a>
+<a href="https://vaadin.com/">Vaadin Home Page</a>
 </p>
 <p>
 Vaadin Plug-in for Eclipse is powered by Eclipse technology and includes Eclipse plug-ins that can be installed and used with other Eclipse-based offerings.<br/>

--- a/com.vaadin.integration.eclipse/about.ini
+++ b/com.vaadin.integration.eclipse/about.ini
@@ -7,7 +7,7 @@ for the development of Rich Internet Applications (RIAs). Deliver web\n\
 applications without worrying about incompatibilities of web browsers, DOM\n\
 or JavaScript by using standard Java tools.\n\ 
 \n\
-Visit http://vaadin.com\n\
+Visit https://vaadin.com\n\
 
 
 ; 32x32 image shown in the about dialog

--- a/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/DownloadManager.java
+++ b/com.vaadin.integration.eclipse/src/com/vaadin/integration/eclipse/util/network/DownloadManager.java
@@ -23,7 +23,7 @@ import com.vaadin.integration.eclipse.util.files.LocalFileManager.FileType;
 
 public class DownloadManager {
 
-    public static final String VAADIN_DOWNLOAD_BASE_URL = "http://vaadin.com/download/";
+    public static final String VAADIN_DOWNLOAD_BASE_URL = "https://vaadin.com/download/";
 
     public static final String VAADIN_LATEST_URL = VAADIN_DOWNLOAD_BASE_URL
             + "LATEST";
@@ -31,7 +31,7 @@ public class DownloadManager {
     private static final String AVAILABLE_VAADIN_VERSIONS_ALL_URL = VAADIN_DOWNLOAD_BASE_URL
             + "VERSIONS_ALL";
 
-    private static final String GWT_DOWNLOAD_URL = "http://vaadin.com/download/external/gwt";
+    private static final String GWT_DOWNLOAD_URL = "https://vaadin.com/download/external/gwt";
 
     private static List<DownloadableVaadinVersion> availableVersions;
 

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -6,7 +6,7 @@
       provider-name="Vaadin Ltd"
       plugin="com.vaadin.integration.eclipse">
 
-   <description url="http://vaadin.com/">
+   <description url="https://vaadin.com/">
       Vaadin Plug-in for Eclipse helps you to create and maintain Vaadin projects, widgetsets, widgets and more.
    </description>
 
@@ -27,7 +27,7 @@ permissions and limitations under the License.
    </license>
 
    <url>
-      <update label="Vaadin Update Site" url="http://vaadin.com/eclipse/"/>
+      <update label="Vaadin Update Site" url="https://vaadin.com/eclipse/"/>
    </url>
 
    <requires>

--- a/features/com.vaadin.integration.eclipse.jarbundle/feature.xml
+++ b/features/com.vaadin.integration.eclipse.jarbundle/feature.xml
@@ -6,7 +6,7 @@
       provider-name="Vaadin Ltd"
       plugin="com.vaadin.integration.eclipse.jarbundle">
 
-   <description url="http://vaadin.com/">
+   <description url="https://vaadin.com/">
       Vaadin Bundle for Eclipse includes the Vaadin jar file and GWT jar files. Everything you need to get started using Vaadin.
    </description>
 
@@ -27,7 +27,7 @@ permissions and limitations under the License.
    </license>
 
    <url>
-      <update label="Vaadin Update Site" url="http://vaadin.com/eclipse/"/>
+      <update label="Vaadin Update Site" url="https://vaadin.com/eclipse/"/>
    </url>
 
    <requires>

--- a/features/com.vaadin.integration.eclipse.manual/feature.xml
+++ b/features/com.vaadin.integration.eclipse.manual/feature.xml
@@ -27,7 +27,7 @@ permissions and limitations under the License.
    </license>
 
    <url>
-      <update label="Vaadin Update Site" url="http://vaadin.com/eclipse/"/>
+      <update label="Vaadin Update Site" url="https://vaadin.com/eclipse/"/>
    </url>
 
    <plugin

--- a/legacy-feature/feature.xml
+++ b/legacy-feature/feature.xml
@@ -6,7 +6,7 @@
       provider-name="Vaadin Ltd"
       plugin="com.vaadin.integration.eclipse">
 
-   <description url="http://vaadin.com/">
+   <description url="https://vaadin.com/">
       Contains the deprecated Vaadin WYSISYG editor, which has been superceded by the Vaadin Designer that provides the same functionality and more. The old WYSIWYG editor can still be used to maintain existing designs. 
    </description>
 
@@ -27,7 +27,7 @@ permissions and limitations under the License.
    </license>
 
    <url>
-      <update label="Vaadin Update Site" url="http://vaadin.com/eclipse/"/>
+      <update label="Vaadin Update Site" url="https://vaadin.com/eclipse/"/>
    </url>
 
    <requires>

--- a/plugins/com.vaadin.integration.eclipse.manual/getting-started.environment.html
+++ b/plugins/com.vaadin.integration.eclipse.manual/getting-started.environment.html
@@ -14,7 +14,7 @@
 		<p>
 			In this example, we use the following toolchain:
 
-			<div class="itemizedlist"><ul type="disc"><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.microsoft.com/windowsxp/" target="_top">Windows XP</a> or Linux or Mac</li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://java.sun.com/javase/downloads/index.jsp" target="_top">Sun Java 2 Standard Edition 6.0</a> (Java 1.5 or newer is required)</li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.eclipse.org/downloads/" target="_top">Eclipse IDE for Java EE Developers (Ganymede version)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://tomcat.apache.org/" target="_top">Apache Tomcat 6.0 (Core)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.getfirefox.com/" target="_top">Firefox 3.0.7</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.getfirebug.com/" target="_top">Firebug 1.3.3 (optional)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/download/" target="_top">Vaadin 6.x.x</a></li></ul></div>
+			<div class="itemizedlist"><ul type="disc"><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.microsoft.com/windowsxp/" target="_top">Windows XP</a> or Linux or Mac</li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://java.sun.com/javase/downloads/index.jsp" target="_top">Sun Java 2 Standard Edition 6.0</a> (Java 1.5 or newer is required)</li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.eclipse.org/downloads/" target="_top">Eclipse IDE for Java EE Developers (Ganymede version)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://tomcat.apache.org/" target="_top">Apache Tomcat 6.0 (Core)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.getfirefox.com/" target="_top">Firefox 3.0.7</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.getfirebug.com/" target="_top">Firebug 1.3.3 (optional)</a></li><li><a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/download/" target="_top">Vaadin 6.x.x</a></li></ul></div>
 
 			The above is a good choice of tools, but you can use almost any tools you are comfortable with.
 		</p>
@@ -285,14 +285,14 @@
 						Select <span class="guibutton">Available Software</span> tab.
 				</li><li>
 					Add the Vaadin plugin update-site by pressing <span class="guibutton">Add Site...</span>. The URL of
-					the site is <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/eclipse" target="_top">http://vaadin.com/eclipse</a>.
+					the site is <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/eclipse" target="_top">http://vaadin.com/eclipse</a>.
 				</li><li>
 					Select to install all pluging on the Vaadin Update Site from the tree and press <span class="guibutton">Install...</span>
 				</li></ol></div>
 	
 			<p>
 				Detailed and up-to-date installation instructions for the Eclipse plugin can be found in 
-				<a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/eclipse" target="_top">http://vaadin.com/eclipse</a>. 
+				<a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/eclipse" target="_top">http://vaadin.com/eclipse</a>. 
 			</p>
 			
 			<div class="note" style="margin-left: 0.5in; margin-right: 0.5in;"><h3 class="title">Eclipse plugin includes everything you need </h3>

--- a/plugins/com.vaadin.integration.eclipse.manual/getting-started.html
+++ b/plugins/com.vaadin.integration.eclipse.manual/getting-started.html
@@ -33,7 +33,7 @@
 			<div class="orderedlist"><ol type="1"><li>
 					<p>
 						Download the newest Vaadin installation package from the download
-						page at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/download/" target="_top">http://vaadin.com/download/</a>. Select
+						page at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/download/" target="_top">http://vaadin.com/download/</a>. Select
 						the proper download package for your operating system: Windows,
 						Linux, or Mac OS X.
 					</p>
@@ -97,7 +97,7 @@
 				allows you to browse documentation and example source code, and run the
 				demo applications. The demo applications demonstrate most of the core
 				features of Vaadin.  You can find the demo applications also at
-				the vaadin website: <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/demo" target="_top">http://vaadin.com/demo</a>.
+				the vaadin website: <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/demo" target="_top">http://vaadin.com/demo</a>.
                 
 			</p>
 
@@ -174,7 +174,7 @@ Running in http://localhost:8888
 					Internet Explorer 6-8, Firefox 3, Safari 3 and Opera 9.6. In addition
 					to these, most of the modern web browsers also work event if they
 					are not supported. The definitive list of supported browsers can be
-					found on http://vaadin.com/features.
+					found on https://vaadin.com/features.
 				</div>
 			</div>
 

--- a/plugins/com.vaadin.integration.eclipse.manual/gwt.html
+++ b/plugins/com.vaadin.integration.eclipse.manual/gwt.html
@@ -46,7 +46,7 @@
 			will greatly simplify the process of building new widgets and composing widgetsets.
 			After introducing yourself with the concepts involved with developing custom
 			components, read about the plugin on 
-			http://vaadin.com/eclipse.
+			https://vaadin.com/eclipse.
 		</p>
 	</div>
 

--- a/plugins/com.vaadin.integration.eclipse.manual/layout.html
+++ b/plugins/com.vaadin.integration.eclipse.manual/layout.html
@@ -169,7 +169,7 @@ bottom.addComponent(new Panel());
 				generated code, which is designed to be as reusable as possible, also
 				works as an example of how you create user interfaces with Vaadin. You can
 				find more about the WYSIWYG editor at
-				<code class="uri">http://vaadin.com/eclipse</code>.
+				<code class="uri">https://vaadin.com/eclipse</code>.
 			</p>
 		</div>
 

--- a/plugins/com.vaadin.integration.eclipse.manual/preface.html
+++ b/plugins/com.vaadin.integration.eclipse.manual/preface.html
@@ -10,7 +10,7 @@
 
         <p>
             The Book of Vaadin is available for free download from
-            <code class="uri">http://vaadin.com/</code> and is also included in the Vaadin installation
+            <code class="uri">https://vaadin.com/</code> and is also included in the Vaadin installation
             package. You may find the HTML or the Eclipse Help plugin version more easily
             searchable than the web and PDF editions, but the content is the same. Just
             like the rest of Vaadin, this book is open source.
@@ -32,7 +32,7 @@
             properly covered are the Vaadin Eclipse plugin and the WYSIWYG editor. These
             tools will make building new projects, widgets, widgetsets, themes, and custom
             components considerably easier in future. For up-to-date information about
-            these features, see <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/eclipse" target="_top">http://vaadin.com/eclipse</a>.
+            these features, see <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/eclipse" target="_top">https://vaadin.com/eclipse</a>.
         </p>
 
         <div class="simplesect" lang="en"><div class="titlepage"><div><div><h2 class="title" style="clear: both"><a name="N2008C"></a>Who is This Book For?</h2></div></div></div>
@@ -177,7 +177,7 @@
                         </p>
 					
                         <p>
-                            You can find the demo applications online at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/" target="_top">http://vaadin.com/</a>.
+                            You can find the demo applications online at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/" target="_top">https://vaadin.com/</a>.
                         </p>
                     </dd><dt><span class="term">Address Book Tutorial</span></dt><dd>
                         <p>
@@ -204,7 +204,7 @@
                         </p>
                     </dd><dt><span class="term">Online Documentation</span></dt><dd>
                         <p>
-                            You can read this book online at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/book" target="_top">http://vaadin.com/book</a>. Lots of 
+                            You can read this book online at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/book" target="_top">https://vaadin.com/book</a>. Lots of 
                             additional material, including technical HOWTOs, answers to Frequently Asked
                             Questions and other documentation is also available on
                             <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://dev.vaadin.com/" target="_top">Vaadin web-site</a>.
@@ -224,7 +224,7 @@
             <div class="variablelist"><dl><dt><span class="term">Community Support Forum</span></dt><dd>
                         <p>
                             You can find the user and developer community forum for Vaadin
-                            at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/forum" target="_top">http://vaadin.com/forum</a>. Please
+                            at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/forum" target="_top">https://vaadin.com/forum</a>. Please
                             use the forum to discuss any problems you might encounter,
                             wishes for features, and so on. The answer for your problems
                             may already lie in the forum archives, so searching the
@@ -244,7 +244,7 @@
                         <p>
                             IT Mill offers full commercial support and training services
                             for the Vaadin products. Read more about the commercial products
-                            at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="http://vaadin.com/pro" target="_top">http://vaadin.com/pro</a>
+                            at <a xmlns:xlink="http://www.w3.org/1999/xlink" href="https://vaadin.com/pro" target="_top">https://vaadin.com/pro</a>
                             for details.
                         </p>
                     </dd></dl></div>

--- a/plugins/com.vaadin.integration.eclipse_v1/about.html
+++ b/plugins/com.vaadin.integration.eclipse_v1/about.html
@@ -10,7 +10,7 @@ Copyright &copy; 2008 IT Mill Ltd. All rights reserved.<br/>
 </b>
 </p>
 <p>
-<a href="http://vaadin.com/">Vaadin Home Page</a>
+<a href="https://vaadin.com/">Vaadin Home Page</a>
 </p>
 <p>
 Vaadin Plug-in for Eclipse is powered by Eclipse technology and includes Eclipse plug-ins that can be installed and used with other Eclipse-based offerings.<br/>

--- a/plugins/com.vaadin.integration.eclipse_v1/about.ini
+++ b/plugins/com.vaadin.integration.eclipse_v1/about.ini
@@ -7,7 +7,7 @@ for the development of Rich Internet Applications (RIAs). Deliver web\n\
 applications without worrying about incompatibilities of web browsers, DOM\n\
 or JavaScript by using standard Java tools.\n\ 
 \n\
-Visit http://vaadin.com\n\
+Visit https://vaadin.com\n\
 
 
 ; 32x32 image shown in the about dialog

--- a/plugins/com.vaadin.integration.eclipse_v1/src/com/vaadin/integration/eclipse/util/DownloadUtils.java
+++ b/plugins/com.vaadin.integration.eclipse_v1/src/com/vaadin/integration/eclipse/util/DownloadUtils.java
@@ -47,10 +47,10 @@ public class DownloadUtils {
     // this pattern does not filter out old versions
     private static final String VAADIN_VERSION_PART_PATTERN = "([0-9]*)\\.([0-9])\\.([^.]+)";
 
-    private static final String LATEST_BASE_URL = "http://vaadin.com/download";
+    private static final String LATEST_BASE_URL = "https://vaadin.com/download";
     private static final String LATEST_FILENAME = "LATEST";
-    private static final String VAADIN_DOWNLOAD_BASE_URL = "http://vaadin.com/download/";
-    private static final String GWT_DOWNLOAD_URL = "http://vaadin.com/download/external/gwt";
+    private static final String VAADIN_DOWNLOAD_BASE_URL = "https://vaadin.com/download/";
+    private static final String GWT_DOWNLOAD_URL = "https://vaadin.com/download/external/gwt";
 
     /**
      * A file version for a particular type of files (e.g. Vaadin JAR) and the
@@ -264,7 +264,7 @@ public class DownloadUtils {
 
     // Old IT Mill Toolkit downloads
     private static DownloadInformation TOOLKIT_JAR_DOWNLOAD = new ToolkitDownloadInformation(
-            "itmill-toolkit", "http://vaadin.com/download/release",
+            "itmill-toolkit", "https://vaadin.com/download/release",
             "itmill-toolkit-");
 
     // Vaadin download sites


### PR DESCRIPTION
Relates to issue https://github.com/vaadin/designer-internal/issues/1598

I don't found any dependencies which are still using http.
Just found couple of mentions about http://vaadin.com, updated to https.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eclipse-plugin/799)
<!-- Reviewable:end -->
